### PR TITLE
add pattern for errorformat

### DIFF
--- a/autoload/gnat.vim
+++ b/autoload/gnat.vim
@@ -105,7 +105,13 @@ function gnat#New ()						     " {{{1
       \ 'Pretty_Command'   : '"gnatpp " . expand("%:p")' ,
       \ 'Error_Format'     : '%f:%l:%c: %trror: %m,'   .
 			   \ '%f:%l:%c: %tarning: %m,' .
-			   \ '%f:%l:%c: (%ttyle) %m'}
+			   \ '%f:%l:%c: %tnfo: %m,'    .
+			   \ '%f:%l:%c: %tow: %m,'     .
+			   \ '%f:%l:%c: %tedium: %m,'  .
+			   \ '%f:%l:%c: %tigh: %m,'    .
+			   \ '%f:%l:%c: %theck: %m,'   .
+			   \ '%f:%l:%c: (%ttyle) %m,'   .
+			   \ '%f:%l:%c: %m'}
 
    return l:Retval
 endfunction gnat#New						  " }}}1


### PR DESCRIPTION
Add some pattern to error format, and I suggest to add more. I use makefile to compile my Ada project and set makeprg in vim to have result in quickfix window, with this configuration I need vim match messages from tools like gnatcheck and spark.

```vim
       \ 'Error_Format'     : '%f:%l:%c: %trror: %m,'   .
 			   \ '%f:%l:%c: %tarning: %m,' .
			   \ '%f:%l:%c: %tnfo: %m,'    .          <===== Info messages from compiler
			   \ '%f:%l:%c: %tow: %m,'     .         <===== low level messages from spark
			   \ '%f:%l:%c: %tedium: %m,'  .       <===== medium level messages from spark
			   \ '%f:%l:%c: %tigh: %m,'    .          <===== high level messages from spark
			   \ '%f:%l:%c: %theck: %m,'   .       <===== messages from gnatchek
			   \ '%f:%l:%c: (%ttyle) %m,'   .               
			   \ '%f:%l:%c: %m'}                  <===== compiler messages if option -gnatU is not set
```